### PR TITLE
fixes various things as per pr comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `otelhttp.{Get,Head,Post,PostForm}` convenience wrappers for their `http` counterparts. (#390)
-- Instrumentation for the S3 client github.com/aws/aws-sdk-go/aws/service/s3
+- Instrumentation for the AWS S3 client `github.com/aws/aws-sdk-go/aws/service/s3`. (#416)
 
 ### Changed
 

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/attributes.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/attributes.go
@@ -21,9 +21,9 @@ const (
 	operationGetObject    = "GetObject"
 	operationDeleteObject = "DeleteObject"
 
-	storageOperationKey   = label.Key("storage.operation")
-	storageDestinationKey = label.Key("storage.destination")
-	storageSystemKey      = label.Key("storage.system")
+	storageOperationKey   = label.Key("aws.s3.operation")
+	storageDestinationKey = label.Key("aws.s3.destination")
+	storageSystemKey      = label.Key("aws.s3.system")
 
 	s3StorageSystemValue = "s3"
 

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/config.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/config.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package config sets options for the aws sdk instrumentation
-package config
+package otels3
 
 import (
 	"go.opentelemetry.io/otel"
@@ -21,55 +21,55 @@ import (
 	oteltrace "go.opentelemetry.io/otel/api/trace"
 )
 
-// Config provides options for the aws sdk instrumentation.
-type Config struct {
-	TracerProvider           oteltrace.TracerProvider
-	MetricProvider           otelmetric.MeterProvider
-	Propagators              otel.TextMapPropagator
-	SpanCorrelationInMetrics bool
+// Config provides options for the AWS SDK instrumentation.
+type config struct {
+	TracerProvider  oteltrace.TracerProvider
+	MetricProvider  otelmetric.MeterProvider
+	Propagators     otel.TextMapPropagator
+	SpanCorrelation bool
 }
 
 // Option interface used for setting instrumentation configuration options.
 type Option interface {
-	Apply(*Config)
+	apply(*config)
 }
 
 // OptionFunc provides a wrapper for specifying options in function format
-type OptionFunc func(*Config)
+type optionFunc func(*config)
 
 // Apply will set the option in the provided config.
-func (o OptionFunc) Apply(cfg *Config) {
+func (o optionFunc) apply(cfg *config) {
 	o(cfg)
 }
 
 // WithPropagators specifies propagators to use for extracting
 // information from the HTTP requests. If none are specified, global
 // ones will be used.
-func WithPropagators(propagators otel.TextMapPropagator) OptionFunc {
-	return OptionFunc(func(cfg *Config) {
+func WithPropagators(propagators otel.TextMapPropagator) Option {
+	return optionFunc(func(cfg *config) {
 		cfg.Propagators = propagators
 	})
 }
 
-// WithTracerProvider specifies a tracer provider to use for creating a tracer.
+// WithTracerProvider specifies a TracerProvider to use for creating a Tracer.
 // If none is specified, the global provider is used.
-func WithTracerProvider(provider oteltrace.TracerProvider) OptionFunc {
-	return OptionFunc(func(cfg *Config) {
+func WithTracerProvider(provider oteltrace.TracerProvider) Option {
+	return optionFunc(func(cfg *config) {
 		cfg.TracerProvider = provider
 	})
 }
 
-// WithMeterProvider specifies a metric provider to use for creating a tracer.
+// WithMeterProvider specifies a MeterProvider to use for creating a Meter.
 // If none is specified, the global provider is used.
-func WithMeterProvider(provider otelmetric.MeterProvider) OptionFunc {
-	return OptionFunc(func(cfg *Config) {
+func WithMeterProvider(provider otelmetric.MeterProvider) Option {
+	return optionFunc(func(cfg *config) {
 		cfg.MetricProvider = provider
 	})
 }
 
-// WithSpanCorrelationInMetrics specifies whether span id and trace id should be attached to metrics as labels
-func WithSpanCorrelationInMetrics(v bool) OptionFunc {
-	return OptionFunc(func(cfg *Config) {
-		cfg.SpanCorrelationInMetrics = v
+// WithSpanCorrelation specifies whether span ID and trace ID should be added to metric event as attributes.
+func WithSpanCorrelation(v bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.SpanCorrelation = v
 	})
 }

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/config.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/config.go
@@ -34,7 +34,7 @@ type Option interface {
 	apply(*config)
 }
 
-// OptionFunc provides a wrapper for specifying options in function format
+// optionFunc provides a wrapper for specifying options in function format
 type optionFunc func(*config)
 
 // Apply will set the option in the provided config.

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/doc.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/doc.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package otels3 provides instrumentation for the s3 client github.com/aws/aws-sdk-go/aws/service/s3.
-// It provides wrappers to the interface, adding tracing and duration metrics.
+// Package otels3 instruments the AWS S3 client github.com/aws/aws-sdk-go/aws/service/s3.
+// Both tracing and metric instrumentation is provided by wrapping the S3 client interface with NewInstrumentedS3Client.
 package otels3

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/example/example.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/example/example.go
@@ -43,7 +43,7 @@ func main() {
 		&mocks.MockS3Client{},
 		config.WithTracerProvider(tracerProvider),
 		config.WithMeterProvider(meterProvider),
-		config.WithSpanCorrelationInMetrics(true),
+		config.WithSpanCorrelation(true),
 	)
 
 	if err != nil {

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/example/example.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/example/example.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go/service/config"
 	obsvsS3 "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go/service/otels3"
 	mocks "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go/service/otels3/mocks"
 	otelmetric "go.opentelemetry.io/otel/api/metric"
@@ -41,9 +40,9 @@ func main() {
 
 	client, err := obsvsS3.NewInstrumentedS3Client(
 		&mocks.MockS3Client{},
-		config.WithTracerProvider(tracerProvider),
-		config.WithMeterProvider(meterProvider),
-		config.WithSpanCorrelation(true),
+		obsvsS3.WithTracerProvider(tracerProvider),
+		obsvsS3.WithMeterProvider(meterProvider),
+		obsvsS3.WithSpanCorrelation(true),
 	)
 
 	if err != nil {

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/s3.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/s3.go
@@ -25,8 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 
-	//"github.com/tommy-muehle/go-mnd/config"
-
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go/service/helper"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/api/global"
@@ -85,6 +83,7 @@ func (s *instrumentedS3) PutObjectWithContext(ctx aws.Context, input *s3.PutObje
 		float64(time.Since(startTime).Microseconds()),
 		attrs...,
 	)
+	//append spand if and trace id to metrics on latency on gauge
 	s.counters.operation.Add(ctx, 1, attrs...)
 
 	return output, err

--- a/instrumentation/github.com/aws/aws-sdk-go/service/otels3/s3_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go/service/otels3/s3_test.go
@@ -80,9 +80,9 @@ func assertMetrics(t *testing.T, mockedMeterImp *mockmetric.MeterImpl) {
 	}
 }
 
-func assertSpanCorrelationInMetrics(t *testing.T, spanCorrelationInMetrics bool, mockedMeterImp *mockmetric.MeterImpl, span *mocktrace.Span) {
+func assertSpanCorrelation(t *testing.T, spanCorrelation bool, mockedMeterImp *mockmetric.MeterImpl, span *mocktrace.Span) {
 	for _, measurementBatch := range mockedMeterImp.MeasurementBatches {
-		if spanCorrelationInMetrics {
+		if spanCorrelation {
 			traceID := span.SpanContext().TraceID.String()
 			spanID := span.SpanContext().SpanID.String()
 
@@ -97,8 +97,8 @@ func assertSpanCorrelationInMetrics(t *testing.T, spanCorrelationInMetrics bool,
 
 func Test_instrumentedS3_PutObjectWithContext(t *testing.T) {
 	type fields struct {
-		spanCorrelationInMetrics bool
-		mockSetup                func() (expectedReturn interface{})
+		spanCorrelation bool
+		mockSetup       func() (expectedReturn interface{})
 	}
 	type args struct {
 		ctx   aws.Context
@@ -114,7 +114,7 @@ func Test_instrumentedS3_PutObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.PutObjectWithContext should be delegated to S3.PutObjectWithContext while metrics and spans are linked",
 			fields: fields{
-				spanCorrelationInMetrics: true,
+				spanCorrelation: true,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.PutObjectOutput{}
 					return
@@ -132,7 +132,7 @@ func Test_instrumentedS3_PutObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.PutObjectWithContext should be delegated to S3.PutObjectWithContext while metrics and spans are NOT linked",
 			fields: fields{
-				spanCorrelationInMetrics: false,
+				spanCorrelation: false,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.PutObjectOutput{}
 					return
@@ -160,13 +160,13 @@ func Test_instrumentedS3_PutObjectWithContext(t *testing.T) {
 
 			s3Mock := &mocks.MockS3Client{}
 			s := &instrumentedS3{
-				S3API:                    s3Mock,
-				tracer:                   mockedTracer,
-				meter:                    mockedMeter,
-				propagators:              mockedPropagators,
-				counters:                 mockedCounters,
-				recorders:                mockedRecorders,
-				spanCorrelationInMetrics: tt.fields.spanCorrelationInMetrics,
+				S3API:           s3Mock,
+				tracer:          mockedTracer,
+				meter:           mockedMeter,
+				propagators:     mockedPropagators,
+				counters:        mockedCounters,
+				recorders:       mockedRecorders,
+				spanCorrelation: tt.fields.SpanCorrelation,
 			}
 			expectedReturn := tt.fields.mockSetup()
 			got, err := s.PutObjectWithContext(tt.args.ctx, tt.args.input)
@@ -189,15 +189,15 @@ func Test_instrumentedS3_PutObjectWithContext(t *testing.T) {
 
 			assertMetrics(t, mockedMeterImp)
 
-			assertSpanCorrelationInMetrics(t, tt.fields.spanCorrelationInMetrics, mockedMeterImp, spans[0])
+			assertSpanCorrelation(t, tt.fields.spanCorrelation, mockedMeterImp, spans[0])
 		})
 	}
 }
 
 func Test_instrumentedS3_GetObjectWithContext(t *testing.T) {
 	type fields struct {
-		spanCorrelationInMetrics bool
-		mockSetup                func() (expectedReturn interface{})
+		spanCorrelation bool
+		mockSetup       func() (expectedReturn interface{})
 	}
 	type args struct {
 		ctx   aws.Context
@@ -213,7 +213,7 @@ func Test_instrumentedS3_GetObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.GetObjectWithContext should be delegated to S3.GetObjectWithContext while metrics and spans are linked",
 			fields: fields{
-				spanCorrelationInMetrics: true,
+				spanCorrelation: true,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.GetObjectOutput{}
 					return
@@ -231,7 +231,7 @@ func Test_instrumentedS3_GetObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.GetObjectWithContext should be delegated to S3.GetObjectWithContext while metrics and spans are NOT linked",
 			fields: fields{
-				spanCorrelationInMetrics: false,
+				spanCorrelation: false,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.GetObjectOutput{}
 					return
@@ -259,13 +259,13 @@ func Test_instrumentedS3_GetObjectWithContext(t *testing.T) {
 
 			s3Mock := &mocks.MockS3Client{}
 			s := &instrumentedS3{
-				S3API:                    s3Mock,
-				tracer:                   mockedTracer,
-				meter:                    mockedMeter,
-				propagators:              mockedPropagators,
-				counters:                 mockedCounters,
-				recorders:                mockedRecorders,
-				spanCorrelationInMetrics: tt.fields.spanCorrelationInMetrics,
+				S3API:           s3Mock,
+				tracer:          mockedTracer,
+				meter:           mockedMeter,
+				propagators:     mockedPropagators,
+				counters:        mockedCounters,
+				recorders:       mockedRecorders,
+				spanCorrelation: tt.fields.spanCorrelation,
 			}
 			expectedReturn := tt.fields.mockSetup()
 			got, err := s.GetObjectWithContext(tt.args.ctx, tt.args.input)
@@ -288,15 +288,15 @@ func Test_instrumentedS3_GetObjectWithContext(t *testing.T) {
 
 			assertMetrics(t, mockedMeterImp)
 
-			assertSpanCorrelationInMetrics(t, tt.fields.spanCorrelationInMetrics, mockedMeterImp, spans[0])
+			assertSpanCorrelation(t, tt.fields.spanCorrelation, mockedMeterImp, spans[0])
 		})
 	}
 }
 
 func Test_instrumentedS3_DeleteObjectWithContext(t *testing.T) {
 	type fields struct {
-		spanCorrelationInMetrics bool
-		mockSetup                func() (expectedReturn interface{})
+		spanCorrelation bool
+		mockSetup       func() (expectedReturn interface{})
 	}
 	type args struct {
 		ctx   aws.Context
@@ -312,7 +312,7 @@ func Test_instrumentedS3_DeleteObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.DeleteObjectWithContext should be delegated to S3.DeleteObjectWithContext while metrics and spans are linked",
 			fields: fields{
-				spanCorrelationInMetrics: true,
+				spanCorrelation: true,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.DeleteObjectOutput{}
 					return
@@ -330,7 +330,7 @@ func Test_instrumentedS3_DeleteObjectWithContext(t *testing.T) {
 		{
 			name: "instrumentedS3.DeleteObjectWithContext should be delegated to S3.DeleteObjectWithContext while metrics and spans are NOT linked",
 			fields: fields{
-				spanCorrelationInMetrics: false,
+				spanCorrelation: false,
 				mockSetup: func() (expectedReturn interface{}) {
 					expectedReturn = &s3.DeleteObjectOutput{}
 					return
@@ -358,13 +358,13 @@ func Test_instrumentedS3_DeleteObjectWithContext(t *testing.T) {
 
 			s3Mock := &mocks.MockS3Client{}
 			s := &instrumentedS3{
-				S3API:                    s3Mock,
-				tracer:                   mockedTracer,
-				meter:                    mockedMeter,
-				propagators:              mockedPropagators,
-				counters:                 mockedCounters,
-				recorders:                mockedRecorders,
-				spanCorrelationInMetrics: tt.fields.spanCorrelationInMetrics,
+				S3API:           s3Mock,
+				tracer:          mockedTracer,
+				meter:           mockedMeter,
+				propagators:     mockedPropagators,
+				counters:        mockedCounters,
+				recorders:       mockedRecorders,
+				spanCorrelation: tt.fields.spanCorrelation,
 			}
 			expectedReturn := tt.fields.mockSetup()
 			got, err := s.DeleteObjectWithContext(tt.args.ctx, tt.args.input)
@@ -387,7 +387,7 @@ func Test_instrumentedS3_DeleteObjectWithContext(t *testing.T) {
 
 			assertMetrics(t, mockedMeterImp)
 
-			assertSpanCorrelationInMetrics(t, tt.fields.spanCorrelationInMetrics, mockedMeterImp, spans[0])
+			assertSpanCorrelation(t, tt.fields.spanCorrelation, mockedMeterImp, spans[0])
 		})
 	}
 }
@@ -415,12 +415,12 @@ func Test_instrumentedS3_NewInstrumentedS3Client(t *testing.T) {
 					config.WithTracerProvider(tracerProvider),
 					config.WithMeterProvider(meterProvider),
 					config.WithPropagators(mockedPropagator),
-					config.WithSpanCorrelationInMetrics(true),
+					config.WithSpanCorrelation(true),
 				},
 			},
 			verifyFunc: func(t *testing.T, got s3iface.S3API, err error) {
 				assert.Nil(t, err, "error should be nil")
-				assert.Equal(t, got.(*instrumentedS3).spanCorrelationInMetrics, true)
+				assert.Equal(t, got.(*instrumentedS3).spanCorrelation, true)
 				assert.Equal(t, got.(*instrumentedS3).propagators, mockedPropagator)
 				assert.Equal(t, got.(*instrumentedS3).S3API, s3MockClient)
 				assert.NotNil(t, got.(*instrumentedS3).meter, "meter should not be nil")


### PR DESCRIPTION
This is just a first pass of the comments on the PR that includes changes:
* minor changes to comments e.g capitalisation etc.
* remove of an inclusion from the git ignore that conflicted
* change of metric names to be prepended by `aws.s3` to avoid future name conflicts and removal of `storage`
* moves config file into s3 as it is specific to that for now
* makes config unexported/private as well as some of the associated functions
* renames `SpanCorrelationInMetrics` to `SpanCorrelation` as per comment from reviewer that said "This uses the term metrics as a noun instead of an adjective, something we try to avoid. Can we rename this?"